### PR TITLE
chore: bump Go to 1.26.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ module go.opentelemetry.io/collector
 // For the OpenTelemetry Collector Core distribution specifically, see
 // https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol
 
-go 1.24.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.11.1


### PR DESCRIPTION
## Summary
- Bumps `go` directive in `go.mod` to `1.26.0`
- Runs `go mod tidy` to update `go.sum`

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised the minimum Go version to 1.26.0 in go.mod so builds use the latest toolchain and features. This updates the project’s required Go version.

- **Migration**
  - Install Go 1.26+ locally and in CI.
  - Update CI/version matrices to include 1.26.
  - Run go mod tidy if your environment produces go.sum changes.

<sup>Written for commit 3ed7f364a59677f934f21e76bc751016dcb59933. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

