### PR TITLE
feat(exporterhelper): add queue payload codec hook (SAW-6556 backport)

### DIFF
--- a/.chloggen/saw-6556-queue-payload-codec.yaml
+++ b/.chloggen/saw-6556-queue-payload-codec.yaml
@@ -1,5 +1,5 @@
 change_type: enhancement
-component: exporter/exporterhelper
+component: pkg/exporterhelper
 note: Add `WithQueueBatchPayloadCodec` to allow wrapping queue payload encoding/decoding in exporterhelper.
 issues: [5]
 change_logs: [user]

--- a/.chloggen/saw-6556-queue-payload-codec.yaml
+++ b/.chloggen/saw-6556-queue-payload-codec.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: exporter/exporterhelper
+note: Add `WithQueueBatchPayloadCodec` to allow wrapping queue payload encoding/decoding in exporterhelper.
+issues: [5]
+change_logs: [user]

--- a/exporter/exporterhelper/internal/base_exporter.go
+++ b/exporter/exporterhelper/internal/base_exporter.go
@@ -69,6 +69,8 @@ func NewBaseExporter(set exporter.Settings, signal pipeline.Signal, pusher sende
 		}
 	}
 
+	be.applyQueuePayloadCodec()
+
 	// Consumer Sender is always initialized.
 	be.firstSender = sender.NewSender(pusher)
 
@@ -217,12 +219,6 @@ func WithQueueBatch(cfg queuebatch.Config, set queuebatch.Settings[request.Reque
 			o.ExportFailureMessage += " Try enabling sending_queue to survive temporary failures."
 			return nil
 		}
-		if o.queuePayloadCodec != nil && set.Encoding != nil {
-			set.Encoding = payloadCodecEncoding{
-				encoding: set.Encoding,
-				codec:    o.queuePayloadCodec,
-			}
-		}
 		if cfg.StorageID != nil && set.Encoding == nil {
 			return errors.New("`Settings.Encoding` must not be nil when persistent queue is enabled")
 		}
@@ -253,6 +249,7 @@ func WithQueueBatchSettings(set queuebatch.Settings[request.Request]) Option {
 
 // WithQueueBatchPayloadCodec wraps queue payload marshaling/unmarshaling.
 // Encode is applied after Marshal on enqueue, Decode before Unmarshal on dequeue.
+// The codec is applied only when queue encoding is configured.
 func WithQueueBatchPayloadCodec(codec queuePayloadCodec) Option {
 	return func(o *BaseExporter) error {
 		o.queuePayloadCodec = codec
@@ -280,4 +277,20 @@ func (e payloadCodecEncoding) Unmarshal(payload []byte) (context.Context, reques
 		return context.Background(), req, err
 	}
 	return e.encoding.Unmarshal(decoded)
+}
+
+func (be *BaseExporter) applyQueuePayloadCodec() {
+	if be.queuePayloadCodec == nil || be.queueBatchSettings.Encoding == nil {
+		return
+	}
+
+	baseEncoding := be.queueBatchSettings.Encoding
+	if wrapped, ok := baseEncoding.(payloadCodecEncoding); ok {
+		baseEncoding = wrapped.encoding
+	}
+
+	be.queueBatchSettings.Encoding = payloadCodecEncoding{
+		encoding: baseEncoding,
+		codec:    be.queuePayloadCodec,
+	}
 }

--- a/exporter/exporterhelper/internal/base_exporter.go
+++ b/exporter/exporterhelper/internal/base_exporter.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/queue"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/sender"
@@ -48,6 +49,12 @@ type BaseExporter struct {
 
 	queueBatchSettings queuebatch.Settings[request.Request]
 	queueCfg           queuebatch.Config
+	queuePayloadCodec  queuePayloadCodec
+}
+
+type queuePayloadCodec interface {
+	Encode([]byte) ([]byte, error)
+	Decode([]byte) ([]byte, error)
 }
 
 func NewBaseExporter(set exporter.Settings, signal pipeline.Signal, pusher sender.SendFunc[request.Request], options ...Option) (*BaseExporter, error) {
@@ -210,6 +217,12 @@ func WithQueueBatch(cfg queuebatch.Config, set queuebatch.Settings[request.Reque
 			o.ExportFailureMessage += " Try enabling sending_queue to survive temporary failures."
 			return nil
 		}
+		if o.queuePayloadCodec != nil && set.Encoding != nil {
+			set.Encoding = payloadCodecEncoding{
+				encoding: set.Encoding,
+				codec:    o.queuePayloadCodec,
+			}
+		}
 		if cfg.StorageID != nil && set.Encoding == nil {
 			return errors.New("`Settings.Encoding` must not be nil when persistent queue is enabled")
 		}
@@ -236,4 +249,35 @@ func WithQueueBatchSettings(set queuebatch.Settings[request.Request]) Option {
 		o.queueBatchSettings = set
 		return nil
 	}
+}
+
+// WithQueueBatchPayloadCodec wraps queue payload marshaling/unmarshaling.
+// Encode is applied after Marshal on enqueue, Decode before Unmarshal on dequeue.
+func WithQueueBatchPayloadCodec(codec queuePayloadCodec) Option {
+	return func(o *BaseExporter) error {
+		o.queuePayloadCodec = codec
+		return nil
+	}
+}
+
+type payloadCodecEncoding struct {
+	encoding queue.Encoding[request.Request]
+	codec    queuePayloadCodec
+}
+
+func (e payloadCodecEncoding) Marshal(ctx context.Context, req request.Request) ([]byte, error) {
+	payload, err := e.encoding.Marshal(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return e.codec.Encode(payload)
+}
+
+func (e payloadCodecEncoding) Unmarshal(payload []byte) (context.Context, request.Request, error) {
+	decoded, err := e.codec.Decode(payload)
+	if err != nil {
+		var req request.Request
+		return context.Background(), req, err
+	}
+	return e.encoding.Unmarshal(decoded)
 }

--- a/exporter/exporterhelper/internal/base_exporter_test.go
+++ b/exporter/exporterhelper/internal/base_exporter_test.go
@@ -133,6 +133,31 @@ func TestQueueRetryWithDisabledQueue(t *testing.T) {
 	}
 }
 
+func TestWithQueueBatchPayloadCodec(t *testing.T) {
+	qCfg := NewDefaultQueueConfig()
+	codec := prefixCodec{prefix: "codec:"}
+
+	be, err := NewBaseExporter(
+		exportertest.NewNopSettings(exportertest.NopType),
+		pipeline.SignalLogs,
+		noopExport,
+		WithQueueBatchPayloadCodec(codec),
+		WithQueueBatch(qCfg, newFakeQueueBatch()),
+	)
+	require.NoError(t, err)
+
+	encoded, err := be.queueBatchSettings.Encoding.Marshal(context.Background(), &requesttest.FakeRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, "codec:mockRequest", string(encoded))
+
+	_, req, err := be.queueBatchSettings.Encoding.Unmarshal([]byte("codec:mockRequest"))
+	require.NoError(t, err)
+	assert.NotNil(t, req)
+
+	_, _, err = be.queueBatchSettings.Encoding.Unmarshal([]byte("bad:mockRequest"))
+	require.Error(t, err)
+}
+
 func errExport(context.Context, request.Request) error {
 	return errors.New("my error")
 }
@@ -155,4 +180,20 @@ func (f fakeEncoding) Marshal(context.Context, request.Request) ([]byte, error) 
 
 func (f fakeEncoding) Unmarshal([]byte) (context.Context, request.Request, error) {
 	return context.Background(), &requesttest.FakeRequest{}, nil
+}
+
+type prefixCodec struct {
+	prefix string
+}
+
+func (c prefixCodec) Encode(payload []byte) ([]byte, error) {
+	return append([]byte(c.prefix), payload...), nil
+}
+
+func (c prefixCodec) Decode(payload []byte) ([]byte, error) {
+	prefix := []byte(c.prefix)
+	if len(payload) < len(prefix) || string(payload[:len(prefix)]) != c.prefix {
+		return nil, errors.New("invalid payload prefix")
+	}
+	return payload[len(prefix):], nil
 }

--- a/exporter/exporterhelper/internal/base_exporter_test.go
+++ b/exporter/exporterhelper/internal/base_exporter_test.go
@@ -137,25 +137,42 @@ func TestWithQueueBatchPayloadCodec(t *testing.T) {
 	qCfg := NewDefaultQueueConfig()
 	codec := prefixCodec{prefix: "codec:"}
 
-	be, err := NewBaseExporter(
-		exportertest.NewNopSettings(exportertest.NopType),
-		pipeline.SignalLogs,
-		noopExport,
-		WithQueueBatchPayloadCodec(codec),
-		WithQueueBatch(qCfg, newFakeQueueBatch()),
-	)
-	require.NoError(t, err)
+	t.Run("codec before queue", func(t *testing.T) {
+		be, err := NewBaseExporter(
+			exportertest.NewNopSettings(exportertest.NopType),
+			pipeline.SignalLogs,
+			noopExport,
+			WithQueueBatchPayloadCodec(codec),
+			WithQueueBatch(qCfg, newFakeQueueBatch()),
+		)
+		require.NoError(t, err)
 
-	encoded, err := be.queueBatchSettings.Encoding.Marshal(context.Background(), &requesttest.FakeRequest{})
-	require.NoError(t, err)
-	assert.Equal(t, "codec:mockRequest", string(encoded))
+		encoded, err := be.queueBatchSettings.Encoding.Marshal(context.Background(), &requesttest.FakeRequest{})
+		require.NoError(t, err)
+		assert.Equal(t, "codec:mockRequest", string(encoded))
 
-	_, req, err := be.queueBatchSettings.Encoding.Unmarshal([]byte("codec:mockRequest"))
-	require.NoError(t, err)
-	assert.NotNil(t, req)
+		_, req, err := be.queueBatchSettings.Encoding.Unmarshal([]byte("codec:mockRequest"))
+		require.NoError(t, err)
+		assert.NotNil(t, req)
 
-	_, _, err = be.queueBatchSettings.Encoding.Unmarshal([]byte("bad:mockRequest"))
-	require.Error(t, err)
+		_, _, err = be.queueBatchSettings.Encoding.Unmarshal([]byte("bad:mockRequest"))
+		require.Error(t, err)
+	})
+
+	t.Run("codec after queue", func(t *testing.T) {
+		be, err := NewBaseExporter(
+			exportertest.NewNopSettings(exportertest.NopType),
+			pipeline.SignalLogs,
+			noopExport,
+			WithQueueBatch(qCfg, newFakeQueueBatch()),
+			WithQueueBatchPayloadCodec(codec),
+		)
+		require.NoError(t, err)
+
+		encoded, err := be.queueBatchSettings.Encoding.Marshal(context.Background(), &requesttest.FakeRequest{})
+		require.NoError(t, err)
+		assert.Equal(t, "codec:mockRequest", string(encoded))
+	})
 }
 
 func errExport(context.Context, request.Request) error {

--- a/exporter/exporterhelper/queue_batch.go
+++ b/exporter/exporterhelper/queue_batch.go
@@ -34,6 +34,19 @@ type QueueBatchEncoding[T any] interface {
 	Unmarshal([]byte) (context.Context, T, error)
 }
 
+// QueueBatchPayloadCodec transforms serialized queue payload bytes.
+// It can be used to add optional features such as compression for persistent sending queues.
+type QueueBatchPayloadCodec interface {
+	Encode([]byte) ([]byte, error)
+	Decode([]byte) ([]byte, error)
+}
+
+// WithQueueBatchPayloadCodec overrides the queue payload codec used by WithQueue/WithQueueBatch.
+// It wraps the existing queue encoding and applies Encode on enqueue and Decode on dequeue.
+func WithQueueBatchPayloadCodec(codec QueueBatchPayloadCodec) Option {
+	return internal.WithQueueBatchPayloadCodec(codec)
+}
+
 var ErrQueueIsFull = queue.ErrQueueIsFull
 
 // NewDefaultQueueConfig returns the default config for QueueBatchConfig.


### PR DESCRIPTION
## Summary
- backport queue payload codec hook into exporterhelper on current Sawmills baseline
- add `QueueBatchPayloadCodec` interface and `WithQueueBatchPayloadCodec` option
- include tests for marshal/unmarshal wrapping behavior

## Validation
- cd exporter/exporterhelper && go test ./...

## Context
Backport branch for SAW-6556 to avoid full collector/contrib uplift in this ticket.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a queue payload codec hook in exporterhelper to enable optional payload compression for sending queues. Supports SAW-6556 (loadbalancingexporter-only) without changing default behavior.

- **New Features**
  - Added QueueBatchPayloadCodec and WithQueueBatchPayloadCodec to wrap Marshal/Unmarshal (Encode on enqueue, Decode on dequeue).
  - Wired codec into BaseExporter when provided; applies only if queue Encoding is set, avoids double-wrapping, and is order-independent.
  - Included tests for roundtrip behavior and invalid payload handling.

- **Refactors**
  - Updated changelog entry to use a valid component key.

<sup>Written for commit 1db2895a016231c7098bd90259ba7e119ca1a4ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Queue batch processing now supports custom payload codec configuration through the WithQueueBatchPayloadCodec option
  * Introduced QueueBatchPayloadCodec interface enabling custom encoding/decoding transformations on serialized queue payloads

* **Tests**
  * Added test coverage validating custom payload codec encode/decode behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->