### PR TITLE
feat(exporterhelper): add in-memory encoded queue mode (SAW-6556 backport)

### DIFF
--- a/.chloggen/saw-6556-in-memory-encoding.yaml
+++ b/.chloggen/saw-6556-in-memory-encoding.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: pkg/exporterhelper
+note: Add `WithQueueBatchInMemoryEncoding` to opt in to encoded payload storage for in-memory sending queues.
+issues: [6]
+change_logs: [user]

--- a/.chloggen/saw-6556-queue-payload-codec.yaml
+++ b/.chloggen/saw-6556-queue-payload-codec.yaml
@@ -1,5 +1,5 @@
 change_type: enhancement
 component: pkg/exporterhelper
-note: Add `WithQueueBatchPayloadCodec` to allow wrapping queue payload encoding/decoding in exporterhelper.
+note: Add `WithQueueBatchPayloadCodec` for queue payload transform hooks and `WithQueueBatchInMemoryEncoding` to opt-in to encoded storage in memory queues.
 issues: [5]
 change_logs: [user]

--- a/exporter/exporterhelper/internal/base_exporter.go
+++ b/exporter/exporterhelper/internal/base_exporter.go
@@ -47,9 +47,10 @@ type BaseExporter struct {
 	timeoutCfg TimeoutConfig
 	retryCfg   configretry.BackOffConfig
 
-	queueBatchSettings queuebatch.Settings[request.Request]
-	queueCfg           queuebatch.Config
-	queuePayloadCodec  queuePayloadCodec
+	queueBatchSettings          queuebatch.Settings[request.Request]
+	queueCfg                    queuebatch.Config
+	queuePayloadCodec           queuePayloadCodec
+	queueUseEncodingForInMemory bool
 }
 
 type queuePayloadCodec interface {
@@ -70,6 +71,7 @@ func NewBaseExporter(set exporter.Settings, signal pipeline.Signal, pusher sende
 	}
 
 	be.applyQueuePayloadCodec()
+	be.applyInMemoryQueueEncoding()
 
 	// Consumer Sender is always initialized.
 	be.firstSender = sender.NewSender(pusher)
@@ -257,6 +259,15 @@ func WithQueueBatchPayloadCodec(codec queuePayloadCodec) Option {
 	}
 }
 
+// WithQueueBatchInMemoryEncoding enables queue encoding for in-memory queues.
+// When enabled, requests are marshaled before enqueue and unmarshaled after dequeue.
+func WithQueueBatchInMemoryEncoding(enabled bool) Option {
+	return func(o *BaseExporter) error {
+		o.queueUseEncodingForInMemory = enabled
+		return nil
+	}
+}
+
 type payloadCodecEncoding struct {
 	encoding queue.Encoding[request.Request]
 	codec    queuePayloadCodec
@@ -293,4 +304,12 @@ func (be *BaseExporter) applyQueuePayloadCodec() {
 		encoding: baseEncoding,
 		codec:    be.queuePayloadCodec,
 	}
+}
+
+func (be *BaseExporter) applyInMemoryQueueEncoding() {
+	if !be.queueUseEncodingForInMemory {
+		return
+	}
+
+	be.queueBatchSettings.UseEncodingForInMemory = true
 }

--- a/exporter/exporterhelper/internal/base_exporter_test.go
+++ b/exporter/exporterhelper/internal/base_exporter_test.go
@@ -60,6 +60,11 @@ func TestQueueOptionsWithRequestExporter(t *testing.T) {
 		WithRetry(configretry.NewDefaultBackOffConfig()),
 		WithQueueBatch(qCfg, queuebatch.Settings[request.Request]{}))
 	require.Error(t, err)
+
+	_, err = NewBaseExporter(exportertest.NewNopSettings(exportertest.NopType), pipeline.SignalMetrics, noopExport,
+		WithQueueBatchInMemoryEncoding(true),
+		WithQueueBatch(NewDefaultQueueConfig(), queuebatch.Settings[request.Request]{}))
+	require.ErrorContains(t, err, "`Settings.Encoding` must not be nil when in-memory encoding is enabled")
 }
 
 func TestBaseExporterLogging(t *testing.T) {
@@ -173,6 +178,43 @@ func TestWithQueueBatchPayloadCodec(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "codec:mockRequest", string(encoded))
 	})
+}
+
+func TestWithQueueBatchInMemoryEncoding(t *testing.T) {
+	qCfg := NewDefaultQueueConfig()
+
+	tests := []struct {
+		name    string
+		options []Option
+	}{
+		{
+			name: "option before queue",
+			options: []Option{
+				WithQueueBatchInMemoryEncoding(true),
+				WithQueueBatch(qCfg, newFakeQueueBatch()),
+			},
+		},
+		{
+			name: "option after queue",
+			options: []Option{
+				WithQueueBatch(qCfg, newFakeQueueBatch()),
+				WithQueueBatchInMemoryEncoding(true),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			be, err := NewBaseExporter(
+				exportertest.NewNopSettings(exportertest.NopType),
+				pipeline.SignalLogs,
+				noopExport,
+				tt.options...,
+			)
+			require.NoError(t, err)
+			assert.True(t, be.queueBatchSettings.UseEncodingForInMemory)
+		})
+	}
 }
 
 func errExport(context.Context, request.Request) error {

--- a/exporter/exporterhelper/internal/queue/memory_queue.go
+++ b/exporter/exporterhelper/internal/queue/memory_queue.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"sync"
 
+	"go.uber.org/zap"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
 )
@@ -31,6 +33,7 @@ type memoryQueue[T request.Request] struct {
 	refCounter ReferenceCounter[T]
 	sizer      request.Sizer
 	encoding   Encoding[T]
+	logger     *zap.Logger
 	cap        int64
 
 	mu                     sync.Mutex
@@ -51,6 +54,7 @@ func newMemoryQueue[T request.Request](set Settings[T]) readableQueue[T] {
 		refCounter:             set.ReferenceCounter,
 		sizer:                  request.NewSizer(set.SizerType),
 		encoding:               set.Encoding,
+		logger:                 set.Telemetry.Logger,
 		cap:                    set.Capacity,
 		items:                  &linkedQueue[memoryQueueItem[T]]{},
 		waitForResult:          set.WaitForResult,
@@ -194,6 +198,9 @@ func (mq *memoryQueue[T]) Read(context.Context) (context.Context, T, Done, bool)
 			elCtx, el, err := mq.encoding.Unmarshal(item.payload)
 			if err != nil {
 				mq.onDoneLocked(done.(*blockingDone), err)
+				if mq.logger != nil {
+					mq.logger.Error("Failed to decode in-memory queue item; dropping item", zap.Error(err))
+				}
 				continue
 			}
 			return elCtx, el, done, true

--- a/exporter/exporterhelper/internal/queue/memory_queue.go
+++ b/exporter/exporterhelper/internal/queue/memory_queue.go
@@ -30,28 +30,32 @@ type memoryQueue[T request.Request] struct {
 	component.StartFunc
 	refCounter ReferenceCounter[T]
 	sizer      request.Sizer
+	encoding   Encoding[T]
 	cap        int64
 
-	mu              sync.Mutex
-	hasMoreElements *sync.Cond
-	hasMoreSpace    *cond
-	items           *linkedQueue[T]
-	size            int64
-	stopped         bool
-	waitForResult   bool
-	blockOnOverflow bool
+	mu                     sync.Mutex
+	hasMoreElements        *sync.Cond
+	hasMoreSpace           *cond
+	items                  *linkedQueue[memoryQueueItem[T]]
+	size                   int64
+	stopped                bool
+	waitForResult          bool
+	blockOnOverflow        bool
+	useEncodingForInMemory bool
 }
 
 // newMemoryQueue creates a sized elements channel. Each element is assigned a size by the provided sizer.
 // capacity is the capacity of the queue.
 func newMemoryQueue[T request.Request](set Settings[T]) readableQueue[T] {
 	sq := &memoryQueue[T]{
-		refCounter:      set.ReferenceCounter,
-		sizer:           request.NewSizer(set.SizerType),
-		cap:             set.Capacity,
-		items:           &linkedQueue[T]{},
-		waitForResult:   set.WaitForResult,
-		blockOnOverflow: set.BlockOnOverflow,
+		refCounter:             set.ReferenceCounter,
+		sizer:                  request.NewSizer(set.SizerType),
+		encoding:               set.Encoding,
+		cap:                    set.Capacity,
+		items:                  &linkedQueue[memoryQueueItem[T]]{},
+		waitForResult:          set.WaitForResult,
+		blockOnOverflow:        set.BlockOnOverflow,
+		useEncodingForInMemory: set.UseEncodingForInMemory,
 	}
 	sq.hasMoreElements = sync.NewCond(&sq.mu)
 	sq.hasMoreSpace = newCond(&sq.mu)
@@ -76,11 +80,25 @@ func (mq *memoryQueue[T]) Offer(ctx context.Context, el T) error {
 		return errSizeTooLarge
 	}
 
+	if mq.useEncodingForInMemory {
+		return mq.offerEncoded(ctx, el, elSize)
+	}
+
 	if mq.refCounter != nil {
 		mq.refCounter.Ref(el)
 	}
 
-	done, err := mq.add(ctx, el, elSize)
+	storedCtx := ctx
+	if !mq.waitForResult {
+		// Prevent cancellation and deadline to propagate to the context stored in the queue.
+		// The grpc/http based receivers will cancel the request context after this function returns.
+		storedCtx = context.WithoutCancel(ctx)
+	}
+
+	done, err := mq.add(ctx, memoryQueueItem[T]{
+		ctx:     storedCtx,
+		request: el,
+	}, elSize)
 	if err != nil {
 		// Unref in case of an error since there will not be any async worker to pick it up.
 		if mq.refCounter != nil {
@@ -104,7 +122,39 @@ func (mq *memoryQueue[T]) Offer(ctx context.Context, el T) error {
 	return nil
 }
 
-func (mq *memoryQueue[T]) add(ctx context.Context, el T, elSize int64) (*blockingDone, error) {
+func (mq *memoryQueue[T]) offerEncoded(ctx context.Context, el T, elSize int64) error {
+	marshalCtx := ctx
+	if !mq.waitForResult {
+		// Keep the same context semantics as non-encoded in-memory queue path.
+		marshalCtx = context.WithoutCancel(ctx)
+	}
+
+	payload, err := mq.encoding.Marshal(marshalCtx, el)
+	if err != nil {
+		return err
+	}
+
+	done, err := mq.add(ctx, memoryQueueItem[T]{
+		payload: payload,
+	}, elSize)
+	if err != nil {
+		return err
+	}
+
+	if mq.waitForResult {
+		select {
+		case doneErr := <-done.ch:
+			blockingDonePool.Put(done)
+			return doneErr
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	return nil
+}
+
+func (mq *memoryQueue[T]) add(ctx context.Context, el memoryQueueItem[T], elSize int64) (*blockingDone, error) {
 	mq.mu.Lock()
 	defer mq.mu.Unlock()
 
@@ -121,14 +171,7 @@ func (mq *memoryQueue[T]) add(ctx context.Context, el T, elSize int64) (*blockin
 	mq.size += elSize
 	done := blockingDonePool.Get().(*blockingDone)
 	done.reset(elSize, mq)
-
-	if !mq.waitForResult {
-		// Prevent cancellation and deadline to propagate to the context stored in the queue.
-		// The grpc/http based receivers will cancel the request context after this function returns.
-		ctx = context.WithoutCancel(ctx)
-	}
-
-	mq.items.push(ctx, el, done)
+	mq.items.push(el, done)
 	// Signal one consumer if any.
 	mq.hasMoreElements.Signal()
 	return done, nil
@@ -143,7 +186,16 @@ func (mq *memoryQueue[T]) Read(context.Context) (context.Context, T, Done, bool)
 
 	for {
 		if mq.items.hasElements() {
-			elCtx, el, done := mq.items.pop()
+			item, done := mq.items.pop()
+			if !mq.useEncodingForInMemory {
+				return item.ctx, item.request, done, true
+			}
+
+			elCtx, el, err := mq.encoding.Unmarshal(item.payload)
+			if err != nil {
+				mq.onDoneLocked(done.(*blockingDone), err)
+				continue
+			}
 			return elCtx, el, done, true
 		}
 
@@ -161,6 +213,10 @@ func (mq *memoryQueue[T]) Read(context.Context) (context.Context, T, Done, bool)
 func (mq *memoryQueue[T]) onDone(bd *blockingDone, err error) {
 	mq.mu.Lock()
 	defer mq.mu.Unlock()
+	mq.onDoneLocked(bd, err)
+}
+
+func (mq *memoryQueue[T]) onDoneLocked(bd *blockingDone, err error) {
 	mq.size -= bd.elSize
 	mq.hasMoreSpace.Signal()
 	if mq.waitForResult {
@@ -190,8 +246,13 @@ func (mq *memoryQueue[T]) Capacity() int64 {
 	return mq.cap
 }
 
+type memoryQueueItem[T request.Request] struct {
+	ctx     context.Context
+	request T
+	payload []byte
+}
+
 type node[T any] struct {
-	ctx  context.Context
 	data T
 	done Done
 	next *node[T]
@@ -202,8 +263,8 @@ type linkedQueue[T any] struct {
 	tail *node[T]
 }
 
-func (l *linkedQueue[T]) push(ctx context.Context, data T, done Done) {
-	n := &node[T]{ctx: ctx, data: data, done: done}
+func (l *linkedQueue[T]) push(data T, done Done) {
+	n := &node[T]{data: data, done: done}
 	// If tail is nil means list is empty so update both head and tail to point to same element.
 	if l.tail == nil {
 		l.head = n
@@ -218,7 +279,7 @@ func (l *linkedQueue[T]) hasElements() bool {
 	return l.head != nil
 }
 
-func (l *linkedQueue[T]) pop() (context.Context, T, Done) {
+func (l *linkedQueue[T]) pop() (T, Done) {
 	n := l.head
 	l.head = n.next
 	// If it gets to the last element, then update tail as well.
@@ -226,7 +287,7 @@ func (l *linkedQueue[T]) pop() (context.Context, T, Done) {
 		l.tail = nil
 	}
 	n.next = nil
-	return n.ctx, n.data, n.done
+	return n.data, n.done
 }
 
 type blockingDone struct {

--- a/exporter/exporterhelper/internal/queue/memory_queue_test.go
+++ b/exporter/exporterhelper/internal/queue/memory_queue_test.go
@@ -247,6 +247,60 @@ func BenchmarkMemoryQueueWaitForResult(b *testing.B) {
 	assert.Equal(b, int64(b.N)*100, consumed.Load())
 }
 
+func TestMemoryQueueInMemoryEncodingRoundTrip(t *testing.T) {
+	set := newSettings(request.SizerTypeItems, 7)
+	set.UseEncodingForInMemory = true
+	q := newMemoryQueue[intRequest](set)
+	require.NoError(t, q.Start(context.Background(), componenttest.NewNopHost()))
+	require.NoError(t, q.Offer(context.Background(), 3))
+
+	assert.True(t, consume(q, func(_ context.Context, el intRequest) error {
+		assert.EqualValues(t, 3, el)
+		return nil
+	}))
+
+	require.NoError(t, q.Shutdown(context.Background()))
+}
+
+func TestMemoryQueueInMemoryEncodingDecodeErrorWaitForResult(t *testing.T) {
+	set := newSettings(request.SizerTypeItems, 10)
+	set.NumConsumers = 1
+	set.WaitForResult = true
+	set.UseEncodingForInMemory = true
+	set.Encoding = decodeErrEncoding{}
+	set.ReferenceCounter = nil
+
+	var consumed atomic.Bool
+	q, err := NewQueue(set, func(context.Context, intRequest, Done) {
+		consumed.Store(true)
+	})
+	require.NoError(t, err)
+	require.NoError(t, q.Start(context.Background(), componenttest.NewNopHost()))
+	require.ErrorContains(t, q.Offer(context.Background(), intRequest(1)), "decode failed")
+	assert.False(t, consumed.Load())
+	assert.EqualValues(t, 0, q.Size())
+	require.NoError(t, q.Shutdown(context.Background()))
+}
+
+func TestMemoryQueueInMemoryEncodingRequireEncoding(t *testing.T) {
+	set := newSettings(request.SizerTypeItems, 10)
+	set.UseEncodingForInMemory = true
+	set.Encoding = nil
+	q, err := NewQueue(set, func(context.Context, intRequest, Done) {})
+	require.ErrorContains(t, err, "`Settings.Encoding` must not be nil when in-memory encoding is enabled")
+	require.Nil(t, q)
+}
+
+type decodeErrEncoding struct{}
+
+func (decodeErrEncoding) Marshal(context.Context, intRequest) ([]byte, error) {
+	return []byte("x"), nil
+}
+
+func (decodeErrEncoding) Unmarshal([]byte) (context.Context, intRequest, error) {
+	return context.Background(), 0, errors.New("decode failed")
+}
+
 func consume[T any](q readableQueue[T], consumeFunc func(context.Context, T) error) bool {
 	ctx, req, done, ok := q.Read(context.Background())
 	if !ok {

--- a/exporter/exporterhelper/internal/queue/memory_queue_test.go
+++ b/exporter/exporterhelper/internal/queue/memory_queue_test.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal/request"
@@ -279,6 +281,31 @@ func TestMemoryQueueInMemoryEncodingDecodeErrorWaitForResult(t *testing.T) {
 	require.ErrorContains(t, q.Offer(context.Background(), intRequest(1)), "decode failed")
 	assert.False(t, consumed.Load())
 	assert.EqualValues(t, 0, q.Size())
+	require.NoError(t, q.Shutdown(context.Background()))
+}
+
+func TestMemoryQueueInMemoryEncodingDecodeErrorAsync(t *testing.T) {
+	set := newSettings(request.SizerTypeItems, 10)
+	set.NumConsumers = 1
+	set.WaitForResult = false
+	set.UseEncodingForInMemory = true
+	set.Encoding = decodeErrEncoding{}
+	set.ReferenceCounter = nil
+	logger, observed := observer.New(zap.ErrorLevel)
+	set.Telemetry.Logger = zap.New(logger)
+
+	var consumed atomic.Bool
+	q, err := NewQueue(set, func(context.Context, intRequest, Done) {
+		consumed.Store(true)
+	})
+	require.NoError(t, err)
+	require.NoError(t, q.Start(context.Background(), componenttest.NewNopHost()))
+	require.NoError(t, q.Offer(context.Background(), intRequest(1)))
+
+	require.Eventually(t, func() bool { return q.Size() == 0 }, time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool { return observed.Len() > 0 }, time.Second, 10*time.Millisecond)
+	assert.False(t, consumed.Load())
+	assert.Equal(t, "Failed to decode in-memory queue item; dropping item", observed.All()[0].Message)
 	require.NoError(t, q.Shutdown(context.Background()))
 }
 

--- a/exporter/exporterhelper/internal/queue/queue.go
+++ b/exporter/exporterhelper/internal/queue/queue.go
@@ -65,20 +65,25 @@ type Queue[T any] interface {
 
 // Settings define internal parameters for a new Queue creation.
 type Settings[T request.Request] struct {
-	SizerType        request.SizerType
-	Capacity         int64
-	NumConsumers     int
-	WaitForResult    bool
-	BlockOnOverflow  bool
-	Signal           pipeline.Signal
-	StorageID        *component.ID
-	ReferenceCounter ReferenceCounter[T]
-	Encoding         Encoding[T]
-	ID               component.ID
-	Telemetry        component.TelemetrySettings
+	SizerType              request.SizerType
+	Capacity               int64
+	NumConsumers           int
+	WaitForResult          bool
+	BlockOnOverflow        bool
+	UseEncodingForInMemory bool
+	Signal                 pipeline.Signal
+	StorageID              *component.ID
+	ReferenceCounter       ReferenceCounter[T]
+	Encoding               Encoding[T]
+	ID                     component.ID
+	Telemetry              component.TelemetrySettings
 }
 
 func NewQueue[T request.Request](set Settings[T], next ConsumeFunc[T]) (Queue[T], error) {
+	if set.StorageID == nil && set.UseEncodingForInMemory && set.Encoding == nil {
+		return nil, errors.New("`Settings.Encoding` must not be nil when in-memory encoding is enabled")
+	}
+
 	q := newBaseQueue(set)
 	oq, err := newObsQueue(set, newAsyncQueue(q, set.NumConsumers, next, set.ReferenceCounter))
 	if err != nil {

--- a/exporter/exporterhelper/internal/queuebatch/queue_batch.go
+++ b/exporter/exporterhelper/internal/queuebatch/queue_batch.go
@@ -16,10 +16,11 @@ import (
 
 // Settings is a subset of the queuebatch.Settings that are needed when used within an Exporter.
 type Settings[T any] struct {
-	ReferenceCounter queue.ReferenceCounter[T]
-	Encoding         queue.Encoding[T]
-	Partitioner      Partitioner[T]
-	MergeCtx         func(context.Context, context.Context) context.Context
+	ReferenceCounter       queue.ReferenceCounter[T]
+	Encoding               queue.Encoding[T]
+	UseEncodingForInMemory bool
+	Partitioner            Partitioner[T]
+	MergeCtx               func(context.Context, context.Context) context.Context
 }
 
 // AllSettings defines settings for creating a QueueBatch.
@@ -57,17 +58,18 @@ func NewQueueBatch(
 	}
 
 	q, err := queue.NewQueue(queue.Settings[request.Request]{
-		SizerType:        cfg.Sizer,
-		Capacity:         cfg.QueueSize,
-		NumConsumers:     cfg.NumConsumers,
-		WaitForResult:    cfg.WaitForResult,
-		BlockOnOverflow:  cfg.BlockOnOverflow,
-		Signal:           set.Signal,
-		StorageID:        cfg.StorageID,
-		ReferenceCounter: set.ReferenceCounter,
-		Encoding:         set.Encoding,
-		ID:               set.ID,
-		Telemetry:        set.Telemetry,
+		SizerType:              cfg.Sizer,
+		Capacity:               cfg.QueueSize,
+		NumConsumers:           cfg.NumConsumers,
+		WaitForResult:          cfg.WaitForResult,
+		BlockOnOverflow:        cfg.BlockOnOverflow,
+		UseEncodingForInMemory: set.UseEncodingForInMemory,
+		Signal:                 set.Signal,
+		StorageID:              cfg.StorageID,
+		ReferenceCounter:       set.ReferenceCounter,
+		Encoding:               set.Encoding,
+		ID:                     set.ID,
+		Telemetry:              set.Telemetry,
 	}, b.Consume)
 	if err != nil {
 		return nil, err

--- a/exporter/exporterhelper/queue_batch.go
+++ b/exporter/exporterhelper/queue_batch.go
@@ -47,6 +47,12 @@ func WithQueueBatchPayloadCodec(codec QueueBatchPayloadCodec) Option {
 	return internal.WithQueueBatchPayloadCodec(codec)
 }
 
+// WithQueueBatchInMemoryEncoding enables queue encoding for in-memory queues.
+// It marshals requests before enqueue and unmarshals requests after dequeue.
+func WithQueueBatchInMemoryEncoding(enabled bool) Option {
+	return internal.WithQueueBatchInMemoryEncoding(enabled)
+}
+
 var ErrQueueIsFull = queue.ErrQueueIsFull
 
 // NewDefaultQueueConfig returns the default config for QueueBatchConfig.


### PR DESCRIPTION
## Summary
- add `WithQueueBatchInMemoryEncoding` option in exporterhelper
- add in-memory queue encoded storage path (marshal on enqueue, unmarshal on dequeue)
- keep default behavior unchanged; mode is opt-in
- add tests for option wiring, encode/decode path, decode error propagation, and validation

## Testing
- go test ./... -count=1 -timeout 8m (in exporter/exporterhelper)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in encoded in-memory queue mode in exporterhelper to enable compressed queue payloads for the loadbalancingexporter (SAW-6556). Default behavior stays the same; when enabled, requests are marshaled on enqueue and unmarshaled on dequeue, with async decode failures now logged.

- **New Features**
  - Option: WithQueueBatchInMemoryEncoding(true) to store encoded entries in in-memory queues; plumbed via Encoding.Marshal/Unmarshal.
  - Validation: errors if enabled without an Encoding for in-memory queues; persistent queues are unaffected.
  - Robustness: decode errors complete the entry with error, free capacity, and log drops when waitForResult=false; honors waitForResult semantics.
  - Tests: option wiring, round-trip encode/decode, decode error propagation and async drop logging, and validation.
  - Changelog: updated entries for the in-memory encoding option and payload codec hook.

<sup>Written for commit 5ebed8be630d3089bad768a537312f8e1fe4caa7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

