### PR TITLE
[chore] ci: auto-tag exporterhelper module on main merges

### DIFF
--- a/.chloggen/7-module-tag-exporterhelper.yaml
+++ b/.chloggen/7-module-tag-exporterhelper.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: pkg/exporterhelper
+note: Add CI workflow to auto-tag Sawmills exporterhelper module versions on merges to main.
+issues: [7]
+change_logs: [user]

--- a/.chloggen/7-module-tag-exporterhelper.yaml
+++ b/.chloggen/7-module-tag-exporterhelper.yaml
@@ -1,5 +1,5 @@
 change_type: enhancement
 component: pkg/exporterhelper
-note: Add CI workflow to auto-tag Sawmills exporterhelper module versions on merges to main.
+note: Add CI workflow to auto-tag Sawmills exporterhelper module versions when exporter/exporterhelper changes are pushed/merged to main.
 issues: [7]
 change_logs: [user]

--- a/.github/workflows/module-tag-exporterhelper.yml
+++ b/.github/workflows/module-tag-exporterhelper.yml
@@ -13,9 +13,6 @@ on:
         required: false
         type: string
 
-permissions:
-  contents: write
-
 concurrency:
   group: module-tag-exporterhelper-${{ github.ref }}
   cancel-in-progress: false
@@ -23,6 +20,8 @@ concurrency:
 jobs:
   tag-module:
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     env:
       MODULE_PREFIX: exporter/exporterhelper
@@ -74,5 +73,5 @@ jobs:
           NEW_TAG="${TAG_PREFIX}${NEXT_INDEX}"
 
           echo "Creating ${NEW_TAG} at ${GITHUB_SHA}"
-          git tag "${NEW_TAG}" "${GITHUB_SHA}"
+          git tag -a "${NEW_TAG}" "${GITHUB_SHA}" -m "Sawmills release ${NEW_TAG}"
           git push origin "${NEW_TAG}"

--- a/.github/workflows/module-tag-exporterhelper.yml
+++ b/.github/workflows/module-tag-exporterhelper.yml
@@ -26,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MODULE_PREFIX: exporter/exporterhelper
+      # Intentionally pinned to SAW-6556 backport line.
       DEFAULT_BASE_VERSION: "0.140.1"
     steps:
       - name: Checkout
@@ -39,8 +40,6 @@ jobs:
           INPUT_BASE_VERSION: ${{ github.event.inputs.base_version }}
         run: |
           set -euo pipefail
-
-          git fetch --tags --force
 
           BASE_VERSION="${INPUT_BASE_VERSION}"
           if [[ -z "${BASE_VERSION}" ]]; then
@@ -59,11 +58,16 @@ jobs:
             exit 0
           fi
 
-          LAST_TAG="$(git tag --list "${TAG_PREFIX}*" --sort=-v:refname | head -n1)"
+          readarray -t MATCHING_TAGS < <(git tag --list "${TAG_PREFIX}*" --sort=-v:refname)
+          LAST_TAG="${MATCHING_TAGS[0]:-}"
           if [[ -z "${LAST_TAG}" ]]; then
             NEXT_INDEX=1
           else
             LAST_INDEX="${LAST_TAG##*.}"
+            if [[ ! "${LAST_INDEX}" =~ ^[0-9]+$ ]]; then
+              echo "Unexpected non-numeric tag suffix: ${LAST_INDEX} (tag: ${LAST_TAG})"
+              exit 1
+            fi
             NEXT_INDEX=$((LAST_INDEX + 1))
           fi
 

--- a/.github/workflows/module-tag-exporterhelper.yml
+++ b/.github/workflows/module-tag-exporterhelper.yml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   tag-module:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     env:
       MODULE_PREFIX: exporter/exporterhelper
@@ -34,14 +35,20 @@ jobs:
 
       - name: Compute and create next module tag
         shell: bash
+        env:
+          INPUT_BASE_VERSION: ${{ github.event.inputs.base_version }}
         run: |
           set -euo pipefail
 
           git fetch --tags --force
 
-          BASE_VERSION="${{ github.event.inputs.base_version }}"
+          BASE_VERSION="${INPUT_BASE_VERSION}"
           if [[ -z "${BASE_VERSION}" ]]; then
             BASE_VERSION="${DEFAULT_BASE_VERSION}"
+          fi
+          if [[ ! "${BASE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid base_version '${BASE_VERSION}'. Expected format: X.Y.Z"
+            exit 1
           fi
 
           TAG_PREFIX="${MODULE_PREFIX}/v${BASE_VERSION}-sawmills."

--- a/.github/workflows/module-tag-exporterhelper.yml
+++ b/.github/workflows/module-tag-exporterhelper.yml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MODULE_PREFIX: exporter/exporterhelper
+      # Bootstrap fallback if no module tags exist yet.
+      DEFAULT_BASE_VERSION: "0.140.1"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -50,8 +52,7 @@ jobs:
             done
           fi
           if [[ -z "${BASE_VERSION}" ]]; then
-            echo "Unable to derive base_version from module tags; pass workflow_dispatch input base_version."
-            exit 1
+            BASE_VERSION="${DEFAULT_BASE_VERSION}"
           fi
           if [[ ! "${BASE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Invalid base_version '${BASE_VERSION}'. Expected format: X.Y.Z"

--- a/.github/workflows/module-tag-exporterhelper.yml
+++ b/.github/workflows/module-tag-exporterhelper.yml
@@ -52,7 +52,12 @@ jobs:
             done
           fi
           if [[ -z "${BASE_VERSION}" ]]; then
-            BASE_VERSION="${DEFAULT_BASE_VERSION}"
+            if [[ ${#DISCOVERY_TAGS[@]} -eq 0 ]]; then
+              BASE_VERSION="${DEFAULT_BASE_VERSION}"
+            else
+              echo "Unable to derive base_version from existing module tags; pass workflow_dispatch input base_version."
+              exit 1
+            fi
           fi
           if [[ ! "${BASE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Invalid base_version '${BASE_VERSION}'. Expected format: X.Y.Z"

--- a/.github/workflows/module-tag-exporterhelper.yml
+++ b/.github/workflows/module-tag-exporterhelper.yml
@@ -1,0 +1,67 @@
+name: Module Tag - exporterhelper
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - exporter/exporterhelper/**
+  workflow_dispatch:
+    inputs:
+      base_version:
+        description: Base semver (without v), e.g. 0.140.1
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: module-tag-exporterhelper-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  tag-module:
+    runs-on: ubuntu-latest
+    env:
+      MODULE_PREFIX: exporter/exporterhelper
+      DEFAULT_BASE_VERSION: "0.140.1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute and create next module tag
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git fetch --tags --force
+
+          BASE_VERSION="${{ github.event.inputs.base_version }}"
+          if [[ -z "${BASE_VERSION}" ]]; then
+            BASE_VERSION="${DEFAULT_BASE_VERSION}"
+          fi
+
+          TAG_PREFIX="${MODULE_PREFIX}/v${BASE_VERSION}-sawmills."
+
+          # Idempotency: do not create another tag if this commit was already tagged.
+          if git tag --points-at "${GITHUB_SHA}" --list "${TAG_PREFIX}*" | grep -q .; then
+            echo "Commit ${GITHUB_SHA} already has ${TAG_PREFIX}* tag. Nothing to do."
+            exit 0
+          fi
+
+          LAST_TAG="$(git tag --list "${TAG_PREFIX}*" --sort=-v:refname | head -n1)"
+          if [[ -z "${LAST_TAG}" ]]; then
+            NEXT_INDEX=1
+          else
+            LAST_INDEX="${LAST_TAG##*.}"
+            NEXT_INDEX=$((LAST_INDEX + 1))
+          fi
+
+          NEW_TAG="${TAG_PREFIX}${NEXT_INDEX}"
+
+          echo "Creating ${NEW_TAG} at ${GITHUB_SHA}"
+          git tag "${NEW_TAG}" "${GITHUB_SHA}"
+          git push origin "${NEW_TAG}"

--- a/.github/workflows/module-tag-exporterhelper.yml
+++ b/.github/workflows/module-tag-exporterhelper.yml
@@ -83,5 +83,7 @@ jobs:
           NEW_TAG="${TAG_PREFIX}${NEXT_INDEX}"
 
           echo "Creating ${NEW_TAG} at ${GITHUB_SHA}"
+          GIT_COMMITTER_NAME="github-actions[bot]" \
+          GIT_COMMITTER_EMAIL="41898282+github-actions[bot]@users.noreply.github.com" \
           git tag -a "${NEW_TAG}" "${GITHUB_SHA}" -m "Sawmills release ${NEW_TAG}"
           git push origin "${NEW_TAG}"

--- a/.github/workflows/module-tag-exporterhelper.yml
+++ b/.github/workflows/module-tag-exporterhelper.yml
@@ -25,8 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MODULE_PREFIX: exporter/exporterhelper
-      # Intentionally pinned to SAW-6556 backport line.
-      DEFAULT_BASE_VERSION: "0.140.1"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -42,7 +40,18 @@ jobs:
 
           BASE_VERSION="${INPUT_BASE_VERSION}"
           if [[ -z "${BASE_VERSION}" ]]; then
-            BASE_VERSION="${DEFAULT_BASE_VERSION}"
+            # Discover base semver from latest existing module tag.
+            readarray -t DISCOVERY_TAGS < <(git tag --list "${MODULE_PREFIX}/v*" --sort=-v:refname)
+            for TAG in "${DISCOVERY_TAGS[@]}"; do
+              if [[ "${TAG}" =~ ^${MODULE_PREFIX}/v([0-9]+\.[0-9]+\.[0-9]+)(-sawmills\.[0-9]+)?$ ]]; then
+                BASE_VERSION="${BASH_REMATCH[1]}"
+                break
+              fi
+            done
+          fi
+          if [[ -z "${BASE_VERSION}" ]]; then
+            echo "Unable to derive base_version from module tags; pass workflow_dispatch input base_version."
+            exit 1
           fi
           if [[ ! "${BASE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Invalid base_version '${BASE_VERSION}'. Expected format: X.Y.Z"
@@ -52,7 +61,8 @@ jobs:
           TAG_PREFIX="${MODULE_PREFIX}/v${BASE_VERSION}-sawmills."
 
           # Idempotency: do not create another tag if this commit was already tagged.
-          if git tag --points-at "${GITHUB_SHA}" --list "${TAG_PREFIX}*" | grep -q .; then
+          readarray -t CURRENT_COMMIT_TAGS < <(git tag --points-at "${GITHUB_SHA}" --list "${TAG_PREFIX}*")
+          if [[ ${#CURRENT_COMMIT_TAGS[@]} -gt 0 ]]; then
             echo "Commit ${GITHUB_SHA} already has ${TAG_PREFIX}* tag. Nothing to do."
             exit 0
           fi


### PR DESCRIPTION
## Summary
- add a focused workflow to auto-create `exporter/exporterhelper` module tags on pushes to `main`
- tag format: `exporter/exporterhelper/v0.140.1-sawmills.N`
- include idempotency guard to avoid duplicate tags on reruns
- add optional manual `workflow_dispatch` override for base version

## Context
SAW-6556


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated module-tagging workflow that creates semantic version tags for the exporterhelper module on merges to main and via manual trigger. Accepts an optional base version, ensures idempotent behavior for already-tagged commits, and increments numeric suffixes for subsequent releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a CI workflow to auto-tag the exporter/exporterhelper module on merges to main for Sawmills releases (SAW-6556). It derives the base version from existing module tags or an optional input, uses a bootstrap default only when no prior module tags exist, and creates annotated tags like exporter/exporterhelper/vX.Y.Z-sawmills.N; sets the committer identity and updates the changelog.

- **New Features**
  - Triggers on pushes to main when exporter/exporterhelper/** changes and via workflow_dispatch; validates X.Y.Z base_version if provided.
  - Enforces main-only guard, concurrency, scoped contents:write, full-history checkout, and idempotent numeric-suffix tagging (discovers base version, computes next sawmills.N, pushes).

<sup>Written for commit 432e93d99d60e00c40d40495c9221dc9425cfad7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

